### PR TITLE
Convert temp to Kelvin, change file paths and add conda environment arg

### DIFF
--- a/process_ceilometer.py
+++ b/process_ceilometer.py
@@ -17,7 +17,7 @@ def get_data(csv_file):
     
     backscatter_array = np.stack(all_the_info_df['backscatter_profile'].to_numpy())
     laser_temp = np.stack(all_the_info_df['laser_temp'].to_numpy())
-    laser_temp = np.array([float(i) for i in laser_temp])
+    laser_temp = np.array([float(i) for i in laser_temp]) + 273.15  # convert C to K
     laser_energy = np.stack(all_the_info_df['energy'].to_numpy())
     laser_energy = np.array([float(i) for i in laser_energy])
     window_transmittance = np.stack(all_the_info_df['window_transmission'].to_numpy())

--- a/scripts/make_netcdf.sh
+++ b/scripts/make_netcdf.sh
@@ -10,11 +10,15 @@ gws_path=/gws/pw/j07/ncas_obs_vol1
 
 netcdf_path=${gws_path}/iao/processing/ncas-ceilometer-3/netcdf_files
 datapath=${gws_path}/iao/raw_data/ncas-ceilometer-3/incoming
-logfilepath=${gws_path}/iao/logs/nc3logs
+logfilepath=${gws_path}/iao/logs/ncas-ceilometer-3
+
 metadata_file=${SCRIPT_DIR}/../metadata.csv
 
 
 datadate=$1  # YYYYmmdd
+conda_env=${2:-netcdf}
+
+conda activate ${conda_env}
 
 python ${SCRIPT_DIR}/../process_ceilometer.py ${datapath}/${datadate}_ceilometer.csv -m ${metadata_file} -o ${netcdf_path} -v
 

--- a/scripts/make_today_netcdf.sh
+++ b/scripts/make_today_netcdf.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# 
+# optional command line argument - conda env
+
+conda_env=${1:-netcdf}
 
 # today date
 
@@ -10,4 +14,4 @@ day=$(date +"%d")
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-${SCRIPT_DIR}/make_netcdf.sh ${year}${month}${day}
+${SCRIPT_DIR}/make_netcdf.sh ${year}${month}${day} ${conda_env}

--- a/scripts/make_yesterday_netcdf.sh
+++ b/scripts/make_yesterday_netcdf.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# 
+# optional command line argument - conda env
+
+conda_env=${1:-netcdf}
 
 # yesterday date
 
@@ -9,4 +13,4 @@ day=$(date --date="yesterday" +"%d")
 # call make_netcdf script
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-${SCRIPT_DIR}/make_netcdf.sh ${year}${month}${day}
+${SCRIPT_DIR}/make_netcdf.sh ${year}${month}${day} ${conda_env}


### PR DESCRIPTION
Change paths to reflect new GWS, and add argument to specify conda environment which activates within `make_netcdf.sh`, with default being environment `netcdf`, convert laser temps from celsius to kelvin