### PR TITLE
corrections for later version of numpy plus spelling

### DIFF
--- a/process_ceilometer.py
+++ b/process_ceilometer.py
@@ -7,10 +7,10 @@ from ncas_amof_netcdf_template import create_netcdf, util, remove_empty_variable
 
 
 def get_data(csv_file):
-    all_the_info_df = read_ceilometer.read_file(csv_file)#.replace('/////',np.NaN)
+    all_the_info_df = read_ceilometer.read_file(csv_file)#.replace('/////',np.nan)
     for col in all_the_info_df.columns:
         if isinstance(all_the_info_df[col][0], str):
-            all_the_info_df[col] = all_the_info_df[col].replace('/////',np.NaN)
+            all_the_info_df[col] = all_the_info_df[col].replace('/////',np.nan)
     time_len = len(all_the_info_df['Timestamp'])
     alt_len = len(all_the_info_df['ranges'][0])
     
@@ -143,7 +143,7 @@ def make_netcdf_cloud_base(csv_file, metadata_file = None, ncfile_location = '.'
     util.update_variable(ncfile, 'laser_temperature', laser_temp)
     util.update_variable(ncfile, 'laser_pulse_energy', laser_energy)
     # yes, there is a spelling mistake in the netCDF file
-    util.update_variable(ncfile, 'window_transmttance', window_transmittance)  
+    util.update_variable(ncfile, 'window_transmittance', window_transmittance)  
     util.update_variable(ncfile, 'backscatter_sum', backscatter_sum)
     util.update_variable(ncfile, 'background_light', background_light)
     util.update_variable(ncfile, 'profile_pulses', pulses)


### PR DESCRIPTION
Later versions of numpy don't accept `np.NaN`. Also spelling correction.